### PR TITLE
Make compatible with metalsmith-permalinks.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -62,7 +62,8 @@ function plugin(options){
           entryProcessor({
             entries      : options.entries,
             template     : options.entry_template,
-            contentTypes : options.contentTypes
+            contentTypes : options.contentTypes,
+            parent       : options.parent
           }),
           done);
       };
@@ -100,7 +101,10 @@ function plugin(options){
           data        : entry,
           id          : entry.sys.id,
           contentType : contentType,
-          template    : options.template
+          template    : options.template,
+          date        : entry.sys.createdAt,
+          parent      : options.parent,
+          slug        : entry.fields.slug
         };
 
         /*


### PR DESCRIPTION
Exposed the following fields to the virtual file object.
- content_entry field 'slug'
- system field 'createdAt'
- entry_template_option 'parent'
